### PR TITLE
Render HTML Void Elements without a closing tag as per spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # elm-html-in-elm
 
 
-A pure Elm represention of Elm Html. This module has been taken from (elm-server-side-renderer)[https://github.com/eeue56/elm-server-side-renderer] and is a pure representation of the Html structure used by VirtualDom. It is designed to be used to allow you to inspect Html nodes, mainly for testing.
+A pure Elm represention of Elm Html. This module has been taken from (elm-server-side-renderer)[https://github.com/eeue56/elm-server-side-renderer] and is a pure representation of the Html structure used by VirtualDom. It is designed to allow you to inspect Html nodes
 
-This package is intended for testing use, with [elm-html-test](http://package.elm-lang.org/eeue56/elm-html-test).
+This package is used to support testing with [elm-html-test](http://package.elm-lang.org/packages/eeue56/elm-html-test/latest).
+
+This package is also used to support using Elm as to generate static files for
+your site with [elm-static-html](https://github.com/eeue56/elm-static-html)

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.1",
+    "version": "2.1.1",
     "summary": "A pure Elm representation of Elm Html",
     "repository": "https://github.com/eeue56/elm-html-in-elm.git",
     "license": "BSD3",

--- a/src/ElmHtml/InternalTypes.elm
+++ b/src/ElmHtml/InternalTypes.elm
@@ -316,6 +316,7 @@ emptyFacts =
    elements must not have closing tags and most not be written as self closing
    either
 -}
+voidElements : List String
 voidElements =
     [ "area"
     , "base"
@@ -338,6 +339,7 @@ voidElements =
    can contain only text and have restrictions on which characters can appear
    within its innerHTML
 -}
+rawTextElements : List String
 rawTextElements =
     [ "script", "style" ]
 
@@ -347,8 +349,10 @@ rawTextElements =
    not contain an ambiguous ampersand along with addional restrictions:
    https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions
 -}
+escapableRawTextElements : List String
 escapableRawTextElements =
     [ "textarea", "title" ]
+
 
 
 {- Foreign elements are elements from the MathML namespace and the

--- a/src/ElmHtml/InternalTypes.elm
+++ b/src/ElmHtml/InternalTypes.elm
@@ -312,46 +312,62 @@ emptyFacts =
     }
 
 
+{-| A list of Void elements as defined by the HTML5 specification. These
+   elements must not have closing tags and most not be written as self closing
+   either
+-}
+voidElements =
+    [ "area"
+    , "base"
+    , "br"
+    , "col"
+    , "embed"
+    , "hr"
+    , "img"
+    , "input"
+    , "link"
+    , "meta"
+    , "param"
+    , "source"
+    , "track"
+    , "wbr"
+    ]
+
+
+{-| A list of all Raw Text Elements as defined by the HTML5 specification. They
+   can contain only text and have restrictions on which characters can appear
+   within its innerHTML
+-}
+rawTextElements =
+    [ "script", "style" ]
+
+
+{-| A list of all Escapable Raw Text Elements as defined by the HTML5
+   specification. They can have text and character references, but the text must
+   not contain an ambiguous ampersand along with addional restrictions:
+   https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions
+-}
+escapableRawTextElements =
+    [ "textarea", "title" ]
+
+
+{- Foreign elements are elements from the MathML namespace and the
+   SVG namespace. TODO: detect these nodes and handle them correctly. Right
+   now they will just be treated as Normal elements.
+-}
+
+
 {-| Identify the kind of element. Helper to convert an tag name into a type for
 pattern matching.
 -}
 toElementKind : String -> ElementKind
 toElementKind element =
-    let
-        voidElements =
-            [ "area"
-            , "base"
-            , "br"
-            , "col"
-            , "embed"
-            , "hr"
-            , "img"
-            , "input"
-            , "link"
-            , "meta"
-            , "param"
-            , "source"
-            , "track"
-            , "wbr"
-            ]
-
-        rawTextElements =
-            [ "script", "style" ]
-
-        escapableRawTextElements =
-            [ "textarea", "title" ]
-
-        {- Foreign elements are elements from the MathML namespace and the
-           SVG namespace. TODO: detect these nodes and handle them correctly. Right
-           now they will just be treated as Normal elements.
-        -}
-    in
-        if List.member element voidElements then
-            VoidElements
-        else if List.member element rawTextElements then
-            RawTextElements
-        else if List.member element escapableRawTextElements then
-            EscapableRawTextElements
-        else
-            -- All other allowed HTML elements are normal elements
-            NormalElements
+    if List.member element voidElements then
+        VoidElements
+    else if List.member element rawTextElements then
+        RawTextElements
+    else if List.member element escapableRawTextElements then
+        EscapableRawTextElements
+    else
+        -- All other allowed HTML elements are normal elements
+        NormalElements

--- a/src/ElmHtml/ToString.elm
+++ b/src/ElmHtml/ToString.elm
@@ -1,10 +1,11 @@
-module ElmHtml.ToString exposing
-    ( nodeToString
-    , nodeRecordToString
-    , nodeToStringWithOptions
-    , FormatOptions
-    , defaultFormatOptions
-    )
+module ElmHtml.ToString
+    exposing
+        ( nodeToString
+        , nodeRecordToString
+        , nodeToStringWithOptions
+        , FormatOptions
+        , defaultFormatOptions
+        )
 
 {-| Convert ElmHtml to string.
 
@@ -25,6 +26,7 @@ type alias FormatOptions =
     , newLines : Bool
     }
 
+
 {-| default formatting options
 -}
 defaultFormatOptions : FormatOptions
@@ -32,6 +34,7 @@ defaultFormatOptions =
     { indent = 0
     , newLines = False
     }
+
 
 nodeToLines : FormatOptions -> ElmHtml -> List String
 nodeToLines options nodeType =
@@ -51,18 +54,25 @@ nodeToLines options nodeType =
         NoOp ->
             []
 
+
 {-| Convert a given html node to a string based on the type
 -}
 nodeToString : ElmHtml -> String
 nodeToString =
     nodeToStringWithOptions defaultFormatOptions
 
+
 {-| same as nodeToString, but with options
 -}
 nodeToStringWithOptions : FormatOptions -> ElmHtml -> String
 nodeToStringWithOptions options =
     nodeToLines options
-        >> String.join (if options.newLines then "\n" else "")
+        >> String.join
+            (if options.newLines then
+                "\n"
+             else
+                ""
+            )
 
 
 {-| Convert a node record to a string. This basically takes the tag name, then
@@ -126,8 +136,20 @@ nodeRecordToString options { tag, children, facts } =
                 |> List.map (\( k, v ) -> k ++ "=" ++ (String.toLower <| toString v))
                 |> String.join " "
                 |> Just
-
     in
-        [ openTag [ classes, styles, stringAttributes, boolAttributes ] ]
-            ++ childrenStrings
-            ++ [ closeTag ]
+        case toElementKind tag of
+            {- Void elements only have a start tag; end tags must not be
+               specified for void elements.
+            -}
+            VoidElements ->
+                [ openTag [ classes, styles, stringAttributes, boolAttributes ] ]
+
+            {- TODO: implement restrictions for RawTextElements,
+               EscapableRawTextElements. Also handle ForeignElements correctly.
+               For now just punt and use the previous behavior for all other
+               element kinds.
+            -}
+            _ ->
+                [ openTag [ classes, styles, stringAttributes, boolAttributes ] ]
+                    ++ childrenStrings
+                    ++ [ closeTag ]


### PR DESCRIPTION
Use a union type to represent each of the 5 kinds of elements defined in the spec. Created
a helper function to tag a element name as a String and convert it to the union type.
Use pattern matching in  on the new type to control the render behavior
of the closing tags. Left a stub for correctly handling Raw Text element kind and Escaped Raw Text
element kind but did not implement correct rendering of element contents for these kinds.

I also ran `elm-format`  on each of the files I touched which resulted in some collateral changes as well.