### PR TITLE
Add tests and use a Dict for the events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+sudo: false
+
+cache:
+  directories:
+    - tests/elm-stuff/build-artifacts
+
+os:
+  - osx
+  - linux
+
+env:
+  matrix:
+    - ELM_VERSION=0.18 TARGET_NODE_VERSION=node
+    - ELM_VERSION=0.18 TARGET_NODE_VERSION=4.2
+
+before_install:
+  - if [ ${TRAVIS_OS_NAME} == "osx" ];
+    then brew update; brew install nvm; mkdir ~/.nvm; export NVM_DIR=~/.nvm; source $(brew --prefix nvm)/nvm.sh;
+    fi
+
+install:
+  - nvm install $TARGET_NODE_VERSION
+  - nvm use $TARGET_NODE_VERSION
+  - node --version
+  - npm --version
+  - npm install -g elm@$ELM_VERSION
+  - npm install -g elm-test
+
+
+script:
+  - elm-test

--- a/src/ElmHtml/InternalTypes.elm
+++ b/src/ElmHtml/InternalTypes.elm
@@ -83,7 +83,7 @@ type alias CustomNodeRecord =
 -}
 type alias Facts =
     { styles : Dict String String
-    , events : Maybe Json.Decode.Value
+    , events : Dict String Json.Decode.Value
     , attributeNamespace : Maybe Json.Decode.Value
     , stringAttributes : Dict String String
     , boolAttributes : Dict String Bool
@@ -288,13 +288,21 @@ decodeAttributes decoder =
         ]
 
 
+decodeEvents : Json.Decode.Decoder (Dict String Json.Decode.Value)
+decodeEvents =
+    Json.Decode.oneOf
+        [ Json.Decode.field eventKey (Json.Decode.dict Json.Decode.value)
+        , Json.Decode.succeed Dict.empty
+        ]
+
+
 {-| decode fact
 -}
 decodeFacts : Json.Decode.Decoder Facts
 decodeFacts =
     Json.Decode.map5 Facts
         (decodeStyles)
-        (Json.Decode.maybe (Json.Decode.field eventKey Json.Decode.value))
+        (decodeEvents)
         (Json.Decode.maybe (Json.Decode.field attributeNamespaceKey Json.Decode.value))
         (decodeOthers Json.Decode.string)
         (decodeOthers Json.Decode.bool)
@@ -305,7 +313,7 @@ decodeFacts =
 emptyFacts : Facts
 emptyFacts =
     { styles = Dict.empty
-    , events = Nothing
+    , events = Dict.empty
     , attributeNamespace = Nothing
     , stringAttributes = Dict.empty
     , boolAttributes = Dict.empty

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+/elm-stuff/

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,0 +1,13 @@
+port module Main exposing (..)
+
+import Tests
+import Test.Runner.Node exposing (run, TestProgram)
+import Json.Encode exposing (Value)
+
+
+main : TestProgram
+main =
+    run emit Tests.all
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/tests/Native/HtmlAsJson.js
+++ b/tests/Native/HtmlAsJson.js
@@ -2,6 +2,9 @@ var _eeue56$elm_html_in_elm$Native_HtmlAsJson = (function() {
     return {
         toJson: function(html) {
             return html;
-        }
+        },
+        eventHandler: F2(function(eventName, html) {
+            return html.facts.EVENT[eventName];
+        })
     };
 })();

--- a/tests/Native/HtmlAsJson.js
+++ b/tests/Native/HtmlAsJson.js
@@ -1,0 +1,7 @@
+var _eeue56$elm_html_in_elm$Native_HtmlAsJson = (function() {
+    return {
+        toJson: function(html) {
+            return html;
+        }
+    };
+})();

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,0 +1,87 @@
+module Tests exposing (..)
+
+import Dict
+import ElmHtml.InternalTypes exposing (ElmHtml, ElmHtml(..), Facts, NodeRecord, decodeElmHtml)
+import Expect
+import Html exposing (Html, button, div, text)
+import Html.Attributes exposing (class, disabled, value)
+import Json.Decode exposing (decodeValue)
+import Native.HtmlAsJson
+import Test exposing (..)
+
+
+{-| Convert a Html node to a Json
+-}
+toJson : Html a -> Json.Decode.Value
+toJson node =
+    Native.HtmlAsJson.toJson node
+
+
+decodedNode : NodeRecord
+decodedNode =
+    { tag = "div"
+    , children = []
+    , facts = decodedFacts
+    , descendantsCount = 0
+    }
+
+
+decodedFacts : Facts
+decodedFacts =
+    { styles = Dict.fromList []
+    , events = Nothing
+    , attributeNamespace = Nothing
+    , stringAttributes = Dict.fromList []
+    , boolAttributes = Dict.fromList []
+    }
+
+
+fromHtml : Html a -> Result String ElmHtml
+fromHtml =
+    decodeValue decodeElmHtml << toJson
+
+
+all : Test
+all =
+    describe "ElmHtml parsing"
+        [ test "parsing a node" <|
+            \() ->
+                div [] []
+                    |> fromHtml
+                    |> Expect.equal (Ok (NodeEntry decodedNode))
+        , test "parsing a text" <|
+            \() ->
+                text "foo"
+                    |> fromHtml
+                    |> Expect.equal (Ok (TextTag { text = "foo" }))
+        , test "parsing attributes" <|
+            \() ->
+                let
+                    expectedFacts =
+                        { decodedFacts
+                            | stringAttributes = Dict.fromList [ ( "className", "foo" ), ( "value", "bar" ) ]
+                            , boolAttributes = Dict.fromList [ ( "disabled", True ) ]
+                        }
+
+                    expectedButton =
+                        { decodedNode | tag = "button", facts = expectedFacts }
+                in
+                    button [ class "foo", value "bar", disabled True ] []
+                        |> fromHtml
+                        |> Expect.equal (Ok (NodeEntry expectedButton))
+        , test "parsing children" <|
+            \() ->
+                let
+                    expected =
+                        { decodedNode
+                            | children = [ NodeEntry decodedNode, TextTag { text = "foo" } ]
+                            , descendantsCount = 2
+                        }
+                in
+                    div []
+                        [ div [] []
+                        , text "foo"
+                        ]
+                        |> fromHtml
+                        |> Expect.equal (Ok (NodeEntry expected))
+        ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.0.0",
+    "summary": "A pure Elm representation of Elm Html",
+    "repository": "https://github.com/eeue56/elm-html-in-elm.git",
+    "license": "BSD3",
+    "source-directories": [
+        ".",
+        "../src"
+    ],
+    "exposed-modules": [],
+    "native-modules": true,
+    "dependencies": {
+        "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}


### PR DESCRIPTION
I'm doing this because of [PR #15 on elm-html-test](https://github.com/eeue56/elm-html-test/pull/15).

I've changed the parsing of events from `Maybe Json.Decode.Value` to a `Dict String Json.Decode.Value`.

The original idea was to have a custom `Event` type, like `Click | Focus | Input` etc, but `Event` is not comparable, so we cannot make a `Dict Event Json.Decode.Value`.

I've also added tests, and for the tests to be more real I've used a Native module, since this is only for tests hopefully the whole package won't be considered native and won't be prevented from being published

I've copied the .travis.yml file from elm-html-test