### PR TITLE
Parse taggers and put them into the nodes facts so they can be used when trigering events

### DIFF
--- a/src/ElmHtml/Markdown.elm
+++ b/src/ElmHtml/Markdown.elm
@@ -1,4 +1,5 @@
 module ElmHtml.Markdown exposing (..)
+
 {-| Markdown helpers
 
 @docs MarkdownOptions, MarkdownModel, baseMarkdownModel
@@ -6,8 +7,10 @@ module ElmHtml.Markdown exposing (..)
 @docs encodeOptions, encodeMarkdownModel, decodeMarkdownModel
 
 -}
+
 import Json.Encode
 import Json.Decode exposing (field)
+
 
 {-| Just a default markdown model
 -}
@@ -22,6 +25,7 @@ baseMarkdownModel =
     , markdown = ""
     }
 
+
 {-| options markdown expects
 -}
 type alias MarkdownOptions =
@@ -30,6 +34,7 @@ type alias MarkdownOptions =
     , sanitize : Bool
     , smartypants : Bool
     }
+
 
 {-| An internal markdown model. Options are the things you give markdown, markdown is the string
 -}
@@ -46,6 +51,7 @@ encodeOptions : MarkdownOptions -> Json.Decode.Value
 encodeOptions options =
     Json.Encode.null
 
+
 {-| encode markdown model
 -}
 encodeMarkdownModel : MarkdownModel -> Json.Decode.Value
@@ -54,6 +60,7 @@ encodeMarkdownModel model =
         [ ( "options", encodeOptions model.options )
         , ( "markdown", Json.Encode.string model.markdown )
         ]
+
 
 {-| decode a markdown model
 -}

--- a/tests/Native/HtmlAsJson.js
+++ b/tests/Native/HtmlAsJson.js
@@ -5,6 +5,9 @@ var _eeue56$elm_html_in_elm$Native_HtmlAsJson = (function() {
         },
         eventHandler: F2(function(eventName, html) {
             return html.facts.EVENT[eventName];
-        })
+        }),
+        taggerFunction: function(tagger) {
+            return tagger;
+        }
     };
 })();


### PR DESCRIPTION
So, in order to solve [PR #15 on elm-html-test](https://github.com/eeue56/elm-html-test/pull/15) problem with `Html.Map`, we need to save the `tagger` function created by the `tagger` nodes somewhere to apply them later when triggering an event.

Right now the `tagger` nodes were simply ignored, so we couldn't map the events.

I thought of two possibilities, first would be having `Tagger` as another kind of `ElmHtml` node, and then when while querying the DOM we would save the `taggers` in the result of that query to apply them later. I've tried but this was getting a little harder to implement and would also add a profound change to `elm-html-query` API, and I didn't wanted that.

So, the second option was to put the tagger together with the `Facts` of the nodes bellow the parsed `tagger`s during parsing. Then later when querying for a node, the taggers it need will already be there. This approach required no changes in any function signatures, but unfortunately it will still be a major change because I've added a new key `taggers` to the `Facts` type.

I've already tested this approach locally by manually installing this changes and using them on `elm-html-test` and it worked out great.

Cheers!