### PR TITLE
Add msg type to html nodes

### DIFF
--- a/src/ElmHtml/ToString.elm
+++ b/src/ElmHtml/ToString.elm
@@ -36,7 +36,7 @@ defaultFormatOptions =
     }
 
 
-nodeToLines : FormatOptions -> ElmHtml -> List String
+nodeToLines : FormatOptions -> ElmHtml msg -> List String
 nodeToLines options nodeType =
     case nodeType of
         TextTag { text } ->
@@ -57,14 +57,14 @@ nodeToLines options nodeType =
 
 {-| Convert a given html node to a string based on the type
 -}
-nodeToString : ElmHtml -> String
+nodeToString : ElmHtml msg -> String
 nodeToString =
     nodeToStringWithOptions defaultFormatOptions
 
 
 {-| same as nodeToString, but with options
 -}
-nodeToStringWithOptions : FormatOptions -> ElmHtml -> String
+nodeToStringWithOptions : FormatOptions -> ElmHtml msg -> String
 nodeToStringWithOptions options =
     nodeToLines options
         >> String.join
@@ -79,7 +79,7 @@ nodeToStringWithOptions options =
     pulls all the facts into tag declaration, then goes through the children and
     nests them under this one
 -}
-nodeRecordToString : FormatOptions -> NodeRecord -> List String
+nodeRecordToString : FormatOptions -> NodeRecord msg -> List String
 nodeRecordToString options { tag, children, facts } =
     let
         openTag : List (Maybe String) -> String

--- a/tests/Native/HtmlAsJson.js
+++ b/tests/Native/HtmlAsJson.js
@@ -3,6 +3,9 @@ var _eeue56$elm_html_in_elm$Native_HtmlAsJson = (function() {
         toJson: function(html) {
             return html;
         },
+        eventDecoder: function (event) {
+            return event.decoder;
+        },
         eventHandler: F2(function(eventName, html) {
             return html.facts.EVENT[eventName];
         }),

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,9 +1,9 @@
 module Tests exposing (..)
 
 import Dict
-import ElmHtml.InternalTypes exposing (ElmHtml, ElmHtml(..), Facts, NodeRecord, Tagger, decodeElmHtml)
+import ElmHtml.InternalTypes exposing (ElmHtml, ElmHtml(..), Facts, NodeRecord, Tagger, EventHandler, decodeElmHtml)
 import Expect
-import Html exposing (Html, button, div, text)
+import Html exposing (Html, button, div, input, text)
 import Html.Attributes exposing (class, disabled, value)
 import Html.Events exposing (onCheck, onClick, onInput)
 import Json.Decode exposing (decodeValue)
@@ -16,17 +16,35 @@ toJson node =
     Native.HtmlAsJson.toJson node
 
 
+eventDecoder : EventHandler -> Json.Decode.Decoder msg
+eventDecoder eventHandler =
+    Native.HtmlAsJson.eventDecoder eventHandler
+
+
 eventHandler : String -> Html a -> Json.Decode.Value
 eventHandler eventName node =
     Native.HtmlAsJson.eventHandler eventName node
 
 
-taggerFunction : Json.Decode.Value -> (a -> msg)
+taggerFunction : Tagger -> (a -> msg)
 taggerFunction tagger =
     Native.HtmlAsJson.taggerFunction tagger
 
 
-decodedNode : NodeRecord
+taggedEventDecoder : List Tagger -> EventHandler -> Json.Decode.Decoder msg
+taggedEventDecoder taggers eventHandler =
+    case taggers of
+        [] ->
+            (eventDecoder eventHandler)
+
+        [ tagger ] ->
+            Json.Decode.map (taggerFunction tagger) (eventDecoder eventHandler)
+
+        tagger :: taggers ->
+            Json.Decode.map (taggerFunction tagger) (taggedEventDecoder taggers eventHandler)
+
+
+decodedNode : NodeRecord msg
 decodedNode =
     { tag = "div"
     , children = []
@@ -35,20 +53,20 @@ decodedNode =
     }
 
 
-decodedFacts : Facts
+decodedFacts : Facts msg
 decodedFacts =
     { styles = Dict.fromList []
     , events = Dict.fromList []
-    , taggers = []
     , attributeNamespace = Nothing
     , stringAttributes = Dict.fromList []
     , boolAttributes = Dict.fromList []
     }
 
 
-fromHtml : Html a -> Result String ElmHtml
-fromHtml =
-    decodeValue decodeElmHtml << toJson
+fromHtml : Html a -> Result String (ElmHtml msg)
+fromHtml html =
+    toJson html
+        |> decodeValue (decodeElmHtml taggedEventDecoder)
 
 
 type Msg
@@ -110,44 +128,42 @@ all =
                 \() ->
                     let
                         taggedNode =
-                            div [] []
+                            input [ onInput identity ] []
                                 |> Html.map (\msg -> msg ++ "bar")
+                                |> fromHtml
                     in
-                        Expect.equal (simulateMsg taggedNode "foo") "foobar"
+                        taggedNode
+                            |> Result.andThen (simulate "input" "{\"target\": {\"value\": \"foo\"}}")
+                            |> Expect.equal (Ok "foobar")
             , test "adds two taggers to a double mapped button with changing types" <|
                 \() ->
                     let
                         taggedNode =
-                            div [ onClick "somestring" ] []
+                            input [ onInput identity ] []
                                 |> Html.map (\str -> [ str ] ++ [ "bar" ])
                                 |> Html.map (\list -> ( list, "baz" ))
+                                |> fromHtml
                     in
-                        Expect.equal (simulateMsg taggedNode "foo") ( [ "foo", "bar" ], "baz" )
+                        taggedNode
+                            |> Result.andThen (simulate "input" "{\"target\": {\"value\": \"foo\"}}")
+                            |> Expect.equal (Ok ( [ "foo", "bar" ], "baz" ))
             ]
         ]
 
 
-simulateMsg : Html msg -> a -> msg
-simulateMsg parsedHtml =
-    case (fromHtml parsedHtml) of
-        Ok (NodeEntry node) ->
-            applyTaggers node.facts.taggers
+simulate : String -> String -> ElmHtml msg -> Result String msg
+simulate eventName event parsedHtml =
+    case parsedHtml of
+        NodeEntry node ->
+            case Dict.get eventName node.facts.events of
+                Just eventDecoder ->
+                    Json.Decode.decodeString eventDecoder event
+
+                Nothing ->
+                    Err ("Could not find event " ++ eventName ++ " on node")
 
         _ ->
-            Debug.crash "taggers not found"
-
-
-applyTaggers : List Tagger -> a -> msg
-applyTaggers taggers msg =
-    case taggers of
-        [] ->
-            Debug.crash "could not apply empty taggers"
-
-        [ tagger ] ->
-            (taggerFunction tagger msg)
-
-        tagger :: taggers ->
-            applyTaggers taggers (taggerFunction tagger msg)
+            Err "Tried to trigger event on something other than a NodeEntry"
 
 
 testParsingEvent : String -> Html.Attribute a -> Test
@@ -160,7 +176,7 @@ testParsingEvent eventName eventAttribute =
 
                 facts =
                     { decodedFacts
-                        | events = Dict.fromList [ ( eventName, eventHandler eventName node ) ]
+                        | events = Dict.fromList [ ( eventName, eventDecoder (eventHandler eventName node) ) ]
                     }
 
                 expected =


### PR DESCRIPTION
Hello,

Here I am, making breaking changes again.
So, you said that elm-html-in-elm should be the best possible representation of elm-html, but one thing started bothering me: Html always holds the type of the msg it produces, like `Html msg`, while `ElmHtml` doesn't.

This was fine until we started producing events (my fault), then suddenly it felt weird to have some function that did `Html msg -> ElmHtml`, while it should be `Html msg -> ElmHtml msg`. Right now we can get events out of the html on elm-html-test but we don't know its message type, this allows me to test something like this:

```elm
, test "returns msg for input" <|
    \() ->
        input [ onInput String.toUpper ] []
            |> Query.fromHtml
            |> Events.simulate (Input "cats")
            |> Events.expectEvent 5
```

Obviously this Html can only produce String msgs, but the type system doesn't prevent us from expecting an Int because when `fromHtml` is used it looses tracking of the msg type.

It was on that [PR #18 on elm-html-test](https://github.com/eeue56/elm-html-test/pull/18) when you asked me to add msg to the `EventNode` that this problem struck me, so thank you. I've changed the `ElmHtml` type to include the msg, and a much better API appeared (IMO), as elm compiler pointed me out on the right directions.

So, previously, I was saving the "taggers" on the `Facts`, and anybody that wanted to use the events would have to remember to also apply the taggers. Now, instead, to get the html decoder you have to provide a function that somehow knows how to transform an event from an Html node, into a msg type, and the taggers do not get saved on the data produced, instead they are already partially applied on the function that will decode the events. This felt more correct to me.

I'm very sorry that I haven't noted that `ElmHtml` should hold a msg before, and end up making all those breaking changes.

Also, this is not a veery important change, it is not blocking anything, is just fixies a small type inference problem when simulating events. So if you believe it is Ok without this change you can close this.

If merging this, there is then the prs [elm-html-test #19](https://github.com/eeue56/elm-html-test/pull/19) and [elm-html-query #6](https://github.com/eeue56/elm-html-query/pull/6) to be merged.

Cheers